### PR TITLE
Add email_validator dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bleach
 coverage
+email_validator
 flask
 flask-ckeditor
 flask-wtf


### PR DESCRIPTION
Should fix the `Install 'email_validator' for email validation support.` error we're getting on certain email signups