### PR TITLE
Change "newsletter/signup/" to "newsletter/"

### DIFF
--- a/blog/newsletter.py
+++ b/blog/newsletter.py
@@ -19,7 +19,8 @@ class NewsletterSignupForm(FlaskForm):
     submit = SubmitField('Sign Up')
 
 
-# associate the url /signup with the signup view function
+@bp.route('/', methods=('GET', 'POST'))
+# deprecated; kept here in case someone has bookmarked it
 @bp.route('/signup', methods=('GET', 'POST'))
 def signup():
     form = NewsletterSignupForm()


### PR DESCRIPTION
More features are planned for newsletter, but (like blog at "/"), the basic, public-facing features can live at just "newsletter/".